### PR TITLE
Potential fix for code scanning alert no. 123: Bad HTML filtering regexp

### DIFF
--- a/tools/doc/common.mjs
+++ b/tools/doc/common.mjs
@@ -15,7 +15,7 @@ export function arrify(value) {
 export function extractAndParseYAML(text) {
   text = text.trim()
              .replace(/^<!-- YAML/, '')
-             .replace(/-->$/, '');
+             .replace(/--(?:!?)>$/, '');
 
   // js-yaml.load() throws on error.
   const meta = yaml.load(text);


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/ideal-octo-meme/security/code-scanning/123](https://github.com/akabarki76/ideal-octo-meme/security/code-scanning/123)

To fix the issue, the regular expression on line 18 should be updated to account for variations in HTML comment end tags, such as `-->` and `--!>`. This can be achieved by modifying the regular expression to match both patterns. Additionally, using a well-tested library for HTML parsing or sanitization is recommended, but since the code is specifically processing YAML metadata, updating the regular expression is sufficient for this context.

**Steps to fix:**
1. Update the regular expression `/-->$/` to `/--(?:!?)>$/` to match both `-->` and `--!>` as valid HTML comment end tags.
2. Ensure the change does not affect the functionality of the `extractAndParseYAML` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
