### PR TITLE
Potential fix for code scanning alert no. 217: Multiplication result converted to larger type

### DIFF
--- a/deps/icu-small/source/tools/toolutil/toolutil.cpp
+++ b/deps/icu-small/source/tools/toolutil/toolutil.cpp
@@ -406,12 +406,12 @@ utm_hasCapacity(UToolMemory *mem, int32_t capacity) {
         }
 
         if(mem->array==mem->staticArray) {
-            mem->array=uprv_malloc(newCapacity*mem->size);
+            mem->array=uprv_malloc(static_cast<size_t>(newCapacity) * mem->size);
             if(mem->array!=nullptr) {
-                uprv_memcpy(mem->array, mem->staticArray, (size_t)mem->idx*mem->size);
+                uprv_memcpy(mem->array, mem->staticArray, static_cast<size_t>(mem->idx) * mem->size);
             }
         } else {
-            mem->array=uprv_realloc(mem->array, newCapacity*mem->size);
+            mem->array=uprv_realloc(mem->array, static_cast<size_t>(newCapacity) * mem->size);
         }
 
         if(mem->array==nullptr) {


### PR DESCRIPTION
Potential fix for [https://github.com/akabarki76/ideal-octo-meme/security/code-scanning/217](https://github.com/akabarki76/ideal-octo-meme/security/code-scanning/217)

To fix the issue, the multiplication should be performed using a larger integer type, such as `size_t`, to ensure that no overflow occurs. This can be achieved by casting one of the operands (`newCapacity` or `mem->size`) to `size_t` before performing the multiplication. This ensures that the multiplication is carried out in the larger type, avoiding overflow.

The specific changes are:
1. On line 414, cast `newCapacity` to `size_t` before multiplying it by `mem->size`.
2. Ensure that the same fix is applied consistently to similar multiplications in the code, such as on line 409.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
